### PR TITLE
Update to use docker for tests

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,32 @@
+FROM debian:jessie
+MAINTAINER jobar <joseph.allemandou@gmail.com>
+
+# Needed to prevent apt errors with debian image
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+#    apt-get install -y apt-utils
+
+ENV NODE_VERSION "4.x"
+
+# Install needed packages:
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y build-essential curl g++-4.8 net-tools libsasl2-dev
+
+# Install node
+RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - && \
+    apt-get install -y nodejs
+
+# Copy KafkaSSE code to /src/KafkaSSE
+RUN mkdir -p /src/KafkaSSE
+WORKDIR /src/KafkaSSE
+COPY lib ./lib
+COPY test ./test
+COPY .travis.yml ./.travis.yml
+COPY *.* ./
+
+# Install KafkaSSE dependencies
+RUN npm install
+
+# Exec command: run test coverage
+CMD ["npm", "run", "coverage"]

--- a/server.js
+++ b/server.js
@@ -7,6 +7,8 @@ const kafkaSseHandler = require('./index');
 
 const port = 6927;
 
+const kafkaBroker = 'localhost:9092'
+
 /**
  * Kasse test server.
  * Connect to this endpoint at localhost:${port}/:topics.
@@ -22,7 +24,10 @@ class KafkaSSEServer {
         this.server.on('request', (req, res) => {
             const topics = req.url.replace('/', '').split(',');
             console.log(`Handling SSE request for topics ${topics}`);
-            kafkaSseHandler(req, res, topics);
+            const options = {
+                kafkaConfig: { 'metadata.broker.list':  kafkaBroker }
+            }
+            kafkaSseHandler(req, res, topics, options);
         });
     }
 

--- a/test/docker-test.sh
+++ b/test/docker-test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# This code has been tested with:
+# - docker-engine^1.12.4
+# - docker-compose^1.9.0
+# Given it uses version 2 of docker-compose files,
+# it should not be compatible with earlier versions.
+
+# Network name configured in docker file:
+APP_NETWORK="kafka_net"
+
+# Internally used variables
+APP_NAME="testkafkasse"
+DOCKER_COMPOSE_CMD="docker-compose -p ${APP_NAME}"
+IMAGE_NAME="testkafkasse"
+
+# Initialised to empty
+KAFKA_CONTAINERS=""
+
+
+# Build and start kafka/zookeeper containers
+start_kafka() {
+    echo "Building and starting kafka/zookeeper containers."
+    pushd docker > /dev/null
+    ${DOCKER_COMPOSE_CMD} build
+    ${DOCKER_COMPOSE_CMD} up -d
+    popd > /dev/null
+
+    # Check kafka container is running
+    KAFKA_CONTAINERS=$(docker ps | grep "9092/tcp")
+    if [ -z ${KAFKA_CONTAINERS} ]; then
+        echo "No kafka container running - Stopping in error!" && exit 1
+    else
+        echo "Kafka container running - Moving forward!"
+    fi
+}
+
+stop_kafka() {
+    echo "Stopping kafka/zookeeper containers (if any)."
+    pushd docker > /dev/null
+    ${DOCKER_COMPOSE_CMD} stop
+    ${DOCKER_COMPOSE_CMD} rm -f
+    popd > /dev/null
+
+    KAFKA_CONTAINERS=$(docker ps | grep "9092/tcp")
+    if [ -z ${KAFKA_CONTAINERS} ]; then
+        echo "No kafka container running - Good!"
+    else
+        echo "Kafka container still running - Not good!" && exit 1
+    fi
+}
+
+
+build_and_test() {
+    # force rebuild testKafkaSSE image and run it (execute tests)
+    echo "Building ${IMAGE_NAME} docker image."
+    pushd ../ > /dev/null
+    docker build --no-cache -t test_kafkasse .
+    echo "Executing ${IMAGE_NAME} docker image (run tests)."
+    TEST_SUCCESS=$(docker run --rm --net ${APP_NAME}_${APP_NETWORK} ${IMAGE_NAME} | grep "npm ERR!")
+    echo ${TEST_SUCCESS}
+    popd > /dev/null
+
+}
+
+check_test() {
+    if [ -z ${TEST_SUCCESS} ]; then
+        echo "Tests successful !" && exit 0
+    else
+        echo "Tests NOT successful :(" && exit 1
+    fi
+}
+
+
+stop_kafka
+
+start_kafka
+
+# Give some time to containers to start
+sleep 5
+
+build_and_test
+
+stop_kafka
+
+check_test

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    networks:
+      - kafka_net
+  kafka:
+    build: ./kafka
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+    networks:
+      - kafka_net
+
+networks:
+  kafka_net:
+    # using default single-host driver
+    driver: bridge

--- a/test/docker/kafka/dockerfile
+++ b/test/docker/kafka/dockerfile
@@ -1,0 +1,29 @@
+FROM anapsix/alpine-java
+
+MAINTAINER Wurstmeister
+
+RUN apk add --update unzip wget curl jq coreutils
+
+ENV KAFKA_VERSION="0.9.0.1" SCALA_VERSION="2.11"
+ADD download_kafka.sh /tmp/download_kafka.sh
+RUN chmod a+x /tmp/download_kafka.sh && sync && /tmp/download_kafka.sh && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz && ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka
+
+VOLUME ["/kafka"]
+
+ENV KAFKA_HOME /opt/kafka
+ENV PATH ${PATH}:${KAFKA_HOME}/bin
+ENV FIXTURES_DIR /tmp/fixtures
+ADD start_kafka.sh /usr/bin/start_kafka.sh
+ADD load_fixtures.sh /usr/bin/load_fixtures.sh
+ADD test_data1.json ${FIXTURES_DIR}/test_data1.json
+ADD test_data2.json ${FIXTURES_DIR}/test_data2.json
+ADD test_data3.json ${FIXTURES_DIR}/test_data3.json
+
+# The scripts need to have executable permission
+RUN chmod a+x /usr/bin/start_kafka.sh && \
+    chmod a+x /usr/bin/load_fixtures.sh
+
+EXPOSE 9092
+
+# Use "exec" form so that it runs as PID 1 (useful for graceful shutdown)
+CMD ["start_kafka.sh"]

--- a/test/docker/kafka/download_kafka.sh
+++ b/test/docker/kafka/download_kafka.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
+url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/test/docker/kafka/load_fixtures.sh
+++ b/test/docker/kafka/load_fixtures.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+#KAFKA_VERSION="${KAFKA_VERSION:-0.9.0.1}"
+#SCALA_VERSION="${SCALA_VERSION:-2.11}"
+# This will only be used if KAFKA_TOPICS_CMD or
+# KAFKA_CONSOLE_PRODUCER_CMD are not defined.
+#KAFKA_HOME=${KAFKA_HOME:-"../kafka_${SCALA_VERSION}-${KAFKA_VERSION}"}
+
+
+FIXTURES_DIR=${FIXTURES_DIR:-$(dirname $0)}
+KAFKA_ZOOKEEPER_CONNECT=${KAFKA_ZOOKEEPER_CONNECT:-"127.0.0.1:2181"}
+KAFKA_TOPICS_CMD=${KAFKA_TOPICS_CMD:-"$KAFKA_HOME/bin/kafka-topics.sh"}
+KAFKA_CONSOLE_PRODUCER_CMD=${KAFKA_CONSOLE_PRODUCER_CMD:-"$KAFKA_HOME/bin/kafka-console-producer.sh"}
+
+
+dropTopics ( ) {
+  if [ "$#" -eq 1 ]
+  then
+    PATTERN=$1
+    echo "looking for topics named '*${PATTERN}*'..."
+    TOPICS=`${KAFKA_TOPICS_CMD} --zookeeper localhost:2181 --list \
+    	| grep ${PATTERN} \
+    	| grep -v 'marked for deletion$'`
+    for TOPIC in ${TOPICS}; do
+      echo "Dropping topic ${TOPIC}"
+      ${KAFKA_TOPICS_CMD} --zookeeper ${KAFKA_ZOOKEEPER_CONNECT} --delete --topic ${TOPIC} > /dev/null &
+    done
+    wait
+  fi
+}
+
+createTopic ( ) {
+    echo "Creating topic ${1}"
+    ${KAFKA_TOPICS_CMD} --create \
+        --zookeeper ${KAFKA_ZOOKEEPER_CONNECT} \
+        --partitions 1                         \
+        --replication-factor 1                 \
+        --topic $1 > /dev/null
+}
+
+produceTestData ( ) {
+    echo "Producing ${2} into topic ${1}"
+    ${KAFKA_CONSOLE_PRODUCER_CMD} --broker-list localhost:9092 --topic ${1} < ${2}
+}
+
+check ( ) {
+  PORT=$1
+  SERVICE_NAME=$2
+  if [ `netstat -l | grep -q ${PORT}; echo $?` -ne 0 ]; then
+    echo "${SERVICE_NAME} not running, start it first"
+    exit 1
+  fi
+}
+
+if [[ -z "$START_TIMEOUT" ]]; then
+    START_TIMEOUT=600
+fi
+
+start_timeout_exceeded=false
+count=0
+step=10
+while netstat -lnt | awk '$4 ~ /:'$KAFKA_PORT'$/ {exit 1}'; do
+    echo "waiting for kafka to be ready"
+    sleep $step;
+    count=$(expr $count + $step)
+    if [ $count -gt $START_TIMEOUT ]; then
+        start_timeout_exceeded=true
+        break
+    fi
+done
+
+if $start_timeout_exceeded; then
+    echo "Not able to load fixtures (waited for $START_TIMEOUT sec)"
+    exit 1
+fi
+
+echo "Using kafka topics command: $KAFKA_TOPICS_CMD"
+echo "Using kafka console producer command: $KAFKA_CONSOLE_PRODUCER_CMD"
+
+#check 2181 "Zookeeper"
+check 9092 "Kafka"
+dropTopics "kafkaSSE_test_"
+sleep 5
+
+#  TODO: 0 index these topic names and data
+(createTopic kafkaSSE_test_01 && produceTestData kafkaSSE_test_01 ${FIXTURES_DIR}/test_data1.json) &
+(createTopic kafkaSSE_test_02 && produceTestData kafkaSSE_test_02 ${FIXTURES_DIR}/test_data2.json) &
+(createTopic kafkaSSE_test_03 && produceTestData kafkaSSE_test_03 ${FIXTURES_DIR}/test_data3.json) &
+(createTopic kafkaSSE_test_04 && produceTestData kafkaSSE_test_04 ${FIXTURES_DIR}/test_data2.json) &
+
+wait

--- a/test/docker/kafka/start_kafka.sh
+++ b/test/docker/kafka/start_kafka.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+if [[ -z "$KAFKA_PORT" ]]; then
+    export KAFKA_PORT=9092
+fi
+if [[ -z "$KAFKA_ADVERTISED_PORT" ]]; then
+    export KAFKA_ADVERTISED_PORT=9092
+fi
+if [[ -z "$KAFKA_BROKER_ID" ]]; then
+    # By default auto allocate broker ID
+    export KAFKA_BROKER_ID=-1
+fi
+if [[ -z "$KAFKA_LOG_DIRS" ]]; then
+    export KAFKA_LOG_DIRS="/kafka/kafka-logs-$HOSTNAME"
+fi
+if [[ -z "$KAFKA_ZOOKEEPER_CONNECT" ]]; then
+    export KAFKA_ZOOKEEPER_CONNECT=$(env | grep ZK.*PORT_2181_TCP= | sed -e 's|.*tcp://||' | paste -sd ,)
+fi
+
+if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
+    sed -r -i "s/(export KAFKA_HEAP_OPTS)=\"(.*)\"/\1=\"$KAFKA_HEAP_OPTS\"/g" $KAFKA_HOME/bin/kafka-server-start.sh
+    unset KAFKA_HEAP_OPTS
+fi
+
+if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" && -n "$HOSTNAME_COMMAND" ]]; then
+    export KAFKA_ADVERTISED_HOST_NAME=$(eval $HOSTNAME_COMMAND)
+fi
+
+
+for VAR in `env`
+do
+  if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
+    kafka_name=`echo "$VAR" | sed -r "s/KAFKA_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
+    env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
+    if egrep -q "(^|^#)$kafka_name=" $KAFKA_HOME/config/server.properties; then
+        sed -r -i "s@(^|^#)($kafka_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/server.properties #note that no config values may contain an '@' char
+    else
+        echo "$kafka_name=${!env_var}" >> $KAFKA_HOME/config/server.properties
+    fi
+  fi
+done
+
+if [[ -n "$CUSTOM_INIT_SCRIPT" ]] ; then
+  eval $CUSTOM_INIT_SCRIPT
+fi
+
+
+KAFKA_PID=0
+
+# see https://medium.com/@gchudnov/trapping-signals-in-docker-containers-7a57fdda7d86#.bh35ir4u5
+term_handler() {
+  echo 'Stopping Kafka....'
+  if [ $KAFKA_PID -ne 0 ]; then
+    kill -s TERM "$KAFKA_PID"
+    wait "$KAFKA_PID"
+  fi
+  echo 'Kafka stopped.'
+  exit
+}
+
+
+# Capture kill requests to stop properly
+trap "term_handler" SIGHUP SIGINT SIGTERM
+load_fixtures.sh &
+$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
+KAFKA_PID=$!
+
+wait "$KAFKA_PID"

--- a/test/docker/kafka/test_data1.json
+++ b/test/docker/kafka/test_data1.json
@@ -1,0 +1,1 @@
+{"id": 100,"name": "A Swing Set","price": 25.00 ,"tags": ["play", "time"], "user": {"first_name": "Dorkus", "last_name": "Berry"}}

--- a/test/docker/kafka/test_data2.json
+++ b/test/docker/kafka/test_data2.json
@@ -1,0 +1,2 @@
+{"id": 1,"name": "A green door","price": 12.50,"tags": ["door", "green", "product"], "user": {"first_name": "Dingle", "last_name": "Berry"}}
+{"id": 2,"name": "Three red doors","price": 25.00,"tags": ["door", "red", "product"], "user": {"first_name": "Rick", "last_name": "Blabla"}}

--- a/test/docker/kafka/test_data3.json
+++ b/test/docker/kafka/test_data3.json
@@ -1,0 +1,2 @@
+this is bad json!!!
+{"id": 3,"name": "Three red windows","price": 50.00,"tags": ["window", "red"], "user": {"first_name": "Rick", "last_name": "Blabla"}}


### PR DESCRIPTION
Update code to take a kafkaBroker config parameter in test,
copy and reuse fixtures script and data,
provide necessary scripts for docker, and testing script
test/docker-test.sh