### PR TITLE
Refactor disconnect handling and avoid KafkaConsumer memory leak

### DIFF
--- a/lib/KafkaSSE.js
+++ b/lib/KafkaSSE.js
@@ -235,40 +235,54 @@ class KafkaSSE {
             mandatoryKafkaConfig
         );
 
-        // Call this.disconnect() when the http client request or response ends.
-        this.req.on('abort', () => {
-            this.log.debug('HTTP request abort, calling KafkaSSE disconnect.');
-            this.disconnect();
-        });
-        this.req.on('aborted', () => {
-            this.log.debug('HTTP request aborted, calling KafkaSSE disconnect.');
-            this.disconnect();
-        });
-        this.req.on('close', () => {
-            this.log.debug('HTTP request closed, calling KafkaSSE disconnect.');
-            this.disconnect();
-        });
-        this.req.on('error', (e) => {
-            this.log.debug(
+        // Set up HTTP request and response end handlers.
+        // We want to call this.disconnect() in response to any of these
+        // events.  We only need to call this.disconnect() the first time
+        // one of these happens, so disconnect() will call
+        // this.removeHttpEndListners to remove all of these listeners
+        // as soon as disconnect() is called.
+        const onceReqAbort = () => this.disconnect('HTTP request abort');
+        const onceReqAborted = () => this.disconnect('HTTP request aborted');
+        const onceReqClose = () => this.disconnect('HTTP request close');
+        const onceReqError = (e) => {
+            this.log.error(
                 {err: e}, 'HTTP request encountered an error, calling KafkaSSE disconnect.'
             );
-            this.disconnect(e);
-        });
-
-        this.res.on('finish', () => {
-            this.log.debug('HTTP response finished, calling KafkaSSE disconnect.');
-            this.disconnect();
-        });
-        this.res.on('close', () => {
-            this.log.debug('HTTP response closed, calling KafkaSSE disconnect.');
-            this.disconnect();
-        });
-        this.res.on('error', (e) => {
-            this.log.debug(
+            this.disconnect('HTTP request error');
+        };
+        const onceResFinish = () => this.disconnect('HTTP response finish');
+        const onceResClose = () => this.disconnect('HTTP response close');
+        const onceResError = (e) => {
+            this.log.error(
                 {err: e}, 'HTTP response encountered an error, calling KafkaSSE disconnect.'
             );
-            this.disconnect(e);
-        });
+            this.disconnect('HTTP response error');
+        };
+
+        this.req.once('abort', onceReqAbort);
+        this.req.once('aborted', onceReqAborted);
+        this.req.once('close', onceReqClose);
+        this.req.once('error', onceReqError);
+        this.res.once('finish', onceResFinish);
+        this.res.once('close', onceResClose);
+        this.res.once('error', onceResError);
+
+        // Will be called theh first time disconnect() is called to keep it
+        // from being called multiple times as the connection closes.
+        this.removeHttpEndListeners = () => {
+            this.log.debug('Removing all HTTP end listeners.');
+            if (this.req) {
+                this.req.removeListener('abort', onceReqAbort);
+                this.req.removeListener('aborted', onceReqAborted);
+                this.req.removeListener('close', onceReqClose);
+                this.req.removeListener('error', onceReqError);
+            }
+            if (this.res) {
+                this.res.removeListener('finish', onceResFinish);
+                this.res.removeListener('close', onceResClose);
+                this.res.removeListener('error', onceResError);
+            }
+        };
     }
 
 
@@ -278,7 +292,7 @@ class KafkaSSE {
      * is created and the consume loop starts.  Up until _start is called,
      * it is possible to end the request with a sensable HTTP error response.
      * Once _start is called, a 200 response header will be written (via
-     * sseClient.initialize()), and any further errors must be reported to the
+     * sse.start()), and any further errors must be reported to the
      * client by emitting an error SSE event.
      *
      * Upon encountering any error, this.connectErrorHandler will be called.
@@ -346,17 +360,21 @@ class KafkaSSE {
             e = this._error(e);
             this.connectErrorHandler(e);
         })
-        // Close KafkaConsumer, and either this.sse or this.res http response.
         .finally(() => {
-            this.log.debug(
-                'Finally finished consume loop and error handling.  Calling KafkaSSE disconnect.'
-            );
-            this.disconnect();
+            // Just in case we get here for a reason other than the HTTP request closing
+            // or error handling, make sure we disconnect everything properly,
+            // especially the KafkaConsumer.
+            if (!this.is_finished) {
+                return this.disconnect('Finally finished consume loop and error handling');
+            }
         });
 
-        // wait for the `done` event to return
+        // connect() will resolve after the KafkaSSE `done` event is fired by disconnect().
         return new P((resolve, reject) => {
-            this._eventEmitter.on('done', resolve);
+            this._eventEmitter.on('done', () => {
+                this.log.info('KafkaSSE connection done.');
+                resolve();
+            });
         });
     }
 
@@ -434,12 +452,10 @@ class KafkaSSE {
                         `Registering Kafka event ${event} to be handled by ` +
                         `function ${this.options.kafkaEventHandlers[event].name}`
                     );
-                    consumer.on(event, this.options.kafkaEventHandlers[event]);
+                    this.kafkaConsumer.on(event, this.options.kafkaEventHandlers[event]);
                 });
             }
 
-            // Save our consumer.
-            // this.kafkaConsumer = consumer;
             return this.kafkaConsumer;
         })
 
@@ -547,7 +563,7 @@ class KafkaSSE {
 
     _start() {
         // Start the consume -> sse send loop.
-        this.log.info('Initializing sseClient and starting consume loop.');
+        this.log.info('Initializing KafkaSSE connection and starting consume loop.');
 
         const responseHeaders = {};
         let disableSSEFormatting = false;
@@ -563,7 +579,7 @@ class KafkaSSE {
             }
         }
 
-        // Initialize the sse response and start sending
+        // Initialize the SSEResponse and start sending
         // the response in chunked transfer encoding.
         this.sse = new SSEResponse(this.res, {
             headers: responseHeaders,
@@ -587,10 +603,10 @@ class KafkaSSE {
         return this._consume()
 
         .then((kafkaMessage) => {
-            // If the request is finished (by calling this.disconnect()),
+            // If the request is finished (something called this.disconnect()),
             // then exit the consume loop now by returning a resolved promise.
-            if (this.is_finished || !this.sse || this._resFinished()) {
-                this.log.info('KafkaSSE connection finished. Returning from consume loop.');
+            if (this.is_finished) {
+                this.log.debug('KafkaSSE connection finished. Returning from consume loop.');
                 return P.resolve();
             }
             if (!kafkaMessage || !kafkaMessage.message || !kafkaMessage.topic) {
@@ -667,7 +683,7 @@ class KafkaSSE {
     _consume() {
         // If we have finished (by calling this.disconnect),
         // don't try to consume anything.
-        if (this.is_finished || this._resFinished()) {
+        if (this.is_finished) {
             this.log.debug('KafkaSSE connection finished. Not attempting consume.');
             return P.resolve();
         }
@@ -842,45 +858,45 @@ class KafkaSSE {
         return false;
     }
 
+
     /**
-     * Disconnects the KafkaConsumer and closes the sse client or http response.
+     * Disconnects the KafkaConsumer and closes the sse client and/or http response.
      * If disconnect() has already been called, this does nothing.
      *
+     * @param {string} reason Reason disconnect was called, used for logging.
      * @return {Promise} Resolved if disconnect was successful, rejected if errored.
      */
-    disconnect(error) {
+    disconnect(reason) {
+        reason = reason || 'unknown';
         // If disconnect has already been called once, do nothing.
+        // This shouldn't really happen, as the HTTP end listeners will be removed.
         if (this.is_finished) {
-            this.log.debug('KafkaSSE disconnect() has already been called. Doing nothing.');
+            this.log.debug(`KafkaSSE disconnect() has already been called. Doing nothing in response to: ${reason}`);
             return P.resolve();
         }
         this.is_finished = true;
 
-        this.log.info('KafkaSSE disconnecting.');
-        if (error) {
-            this._error(error, 'warn');
-        }
+        this.log.info(`KafkaSSE disconnecting due to: ${reason}`);
 
+        // Remove other HTTP disconnect handlers to prevent disconnect from being fired multiple times.
+        this.removeHttpEndListeners();
 
-        // First deal with the HTTP/SSE response.
-        // 3 cases:
-        // - Usually we are disconnecting an active SSEResponse, so just
-        //   end the HTTP response via this.sse.end.
-        // - If no SSEResponse is active, just end this.res.
-        // - Else this.res is finished but we still have a reference to it
-        //   so just delete this.res.
-        return P.resolve().then(() => {
+        const disconnectHttpPromise = P.resolve().then(() => {
+            // 3 cases:
+            // - Usually we are disconnecting an active SSEResponse, so just
+            //   end the HTTP response via this.sse.end.
+            // - If no SSEResponse is active, just end this.res.
+            // - Else this.res is finished but we still have a reference to it
+            //   so just delete this.res.
             if (this.sse) {
                 // If we still have SSE, then end the SSEResponse.
                 // SSEResponse will handle ending thee HTTP Response itself.
                 const sse = this.sse;
                 delete this.sse;
                 delete this.res;
+
                 return sse.end()
-                .catch((e) => this._error(e, 'warn'))
-                .then(() => {
-                    this.log.debug('KafkaSSE disconnect: Ended SSE + HTTP response.');
-                });
+                .then(() => this.log.debug('KafkaSSE disconnect: Ended SSE (HTTP) response.'));
             } else if (!this._resFinished()) {
                 // Else if for disconnect was called and we don't have an SSEResponse,
                 // (likely because the SSEResponse wasn't ever started), then just
@@ -891,43 +907,48 @@ class KafkaSSE {
                         delete this.res;
                         return resolve();
                     }
+
                     delete this.res;
                     res.on('error', reject);
                     try {
-                        if (!res.end(resolve)) {
-                            resolve();
-                        }
+                        res.end();
+                        resolve();
                     } catch(e) {
                         reject(e);
                     }
-                }).catch((e) => this._error(e, 'warn'))
-                .then(() => {
-                    this.log.debug('KafkaSSE disconnect: Ended HTTP response.');
-                });
+                })
+                .then(() => this.log.debug('KafkaSSE disconnect: Ended HTTP response.'));
             } else if (this.res) {
-                // Else the HTTH Response has already been ended,
+                // Else the HTTP Response has already been ended,
                 // so just delete our reference to it.
                 delete this.res;
-                this.log.debug('KafkaSSE disconnect: Ended HTTP response.');
+                this.log.debug('KafkaSSE disconnect: Deleted HTTP response.');
+                return P.resolve();
             }
-        })
-        // Now disconnect the Kafka Consumer.
-        .then(() => {
+        });
+
+        const disconnectKafkaPromise = P.resolve().then(() => {
             if (!this.kafkaConsumer) {
+                this.log.debug("KafkaSSE disconnect: Kafka consumer already deleted, doing nothing.");
                 return P.resolve();
             }
             const kafkaConsumer = this.kafkaConsumer;
             delete this.kafkaConsumer;
-            return P.try(() => kafkaConsumer.disconnect())
-            .catch((e) => this._error(e, 'warn'))
-            .then(() => {
-                this.log.debug('KafkaSSE disconnect: Disconnected the Kafka consumer.');
-            });
+
+            return kafkaConsumer.disconnectAsync()
+            .then(() => this.log.debug("KafkaSSE disconnect: Disconnected the Kafka consumer."));
+        });
+
+        // Emit 'done' when both HTTP response and Kafka are disconnected.
+        return P.all([disconnectHttpPromise, disconnectKafkaPromise])
+        .catch((e) => {
+            this.log.error({err: e}, 'KafkaSSE disconnect: encountered error');
         })
-        .then(() => {
+        .finally(() => {
             this.log.debug('KafkaSSE disconnect: finished.')
             return this._eventEmitter.emit('done')
         });
+
     }
 }
 

--- a/lib/KafkaSSE.js
+++ b/lib/KafkaSSE.js
@@ -239,7 +239,7 @@ class KafkaSSE {
         // We want to call this.disconnect() in response to any of these
         // events.  We only need to call this.disconnect() the first time
         // one of these happens, so disconnect() will call
-        // this.removeHttpEndListners to remove all of these listeners
+        // this.removeHttpEndListeners to remove all of these listeners
         // as soon as disconnect() is called.
         const onceReqAbort = () => this.disconnect('HTTP request abort');
         const onceReqAborted = () => this.disconnect('HTTP request aborted');

--- a/lib/KafkaSSE.js
+++ b/lib/KafkaSSE.js
@@ -200,6 +200,16 @@ class KafkaSSE {
             'client.id': `KafkaSSE-${this.id}`
         };
 
+        // If we won't be responding to any rdkafka events,
+        // there is no need to set up the rdkafka event emitter.
+        // This is a workaround for a memory leak bug currently
+        // in node-rdkafka: https://github.com/Blizzard/node-rdkafka/issues/731
+        // If you do set any kafkaEventHandlers, be aware you may encounter a
+        // memory leak until this bug is fixed.
+        if (!this.options.kafkaEventHandlers) {
+            defaultKafkaConfig.event_cb = false;
+        }
+
         // These configs MUST be set for a KafkaSSE KafkaConsumer;
         // they are not overridable.
         // We want to avoid making Kafka manage consumer info for external clients:
@@ -216,7 +226,6 @@ class KafkaSSE {
         const mandatoryKafkaConfig = {
             'enable.auto.commit': false,
             'group.id': `KafkaSSE-${this.id}`
-
         };
 
         // Merge provided over default configs, and mandatory over all.

--- a/lib/KafkaSSE.js
+++ b/lib/KafkaSSE.js
@@ -909,7 +909,7 @@ class KafkaSSE {
                     }
 
                     delete this.res;
-                    res.on('error', reject);
+                    res.once('error', reject);
                     try {
                         res.end();
                         resolve();

--- a/lib/SSEResponse.js
+++ b/lib/SSEResponse.js
@@ -161,6 +161,7 @@ class SSEResponse {
         });
     }
 
+
     _resFinished() {
         const res = this.res;
         if (!res || res.finished || (res.connection && res.connection.destroyed)) {

--- a/lib/SSEResponse.js
+++ b/lib/SSEResponse.js
@@ -135,34 +135,31 @@ class SSEResponse {
 
 
     /**
-     * Ends the response.
+     * Ends the HTTP response.
      */
     end() {
         if (!this.res) {
             return P.resolve();
         }
+
         if (this._resFinished()) {
             delete this.res;
             return P.resolve();
         }
+
+        const res = this.res;
+        delete this.res;
+
         return new P((resolve, reject) => {
-            const res = this.res;
-            if (this._resFinished()) {
-                delete this.res;
-                return resolve();
-            }
-            delete this.res;
-            res.on('error', reject);
+            res.once('error', reject);
             try {
-                if (res.end(resolve) === false) {
-                    resolve();
-                }
+                res.end();
+                resolve();
             } catch(e) {
                 reject(e);
             }
         });
     }
-
 
     _resFinished() {
         const res = this.res;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-sse",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "KafkaSSE - Kafka Consumer to HTTP SSE/EventSource",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://phabricator.wikimedia.org/diffusion/WKSE/kafkasse.git"
+    "url": "https://github.com/wikimedia/KafkaSSE.git"
   },
   "keywords": [
     "kafka",
@@ -31,9 +31,9 @@
   "author": "Andrew Otto <otto@wikimedia.org>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://phabricator.wikimedia.org/search/query/fpxAPkMeWqjh/"
+    "url": "https://github.com/wikimedia/KafkaSSE/issues"
   },
-  "homepage": "https://github.com/wikimedia/kafkasse#readme",
+  "homepage": "https://github.com/wikimedia/KafkaSSE#readme",
   "dependencies": {
     "bluebird": "^3.5.1",
     "bunyan": "^1.8.1",


### PR DESCRIPTION
- node-rdkafka event_cb is set to false if kafkaEventHandlers are not used.  This avoids a memory leak bug: https://github.com/Blizzard/node-rdkafka/issues/731

- res.end(reject) was used to resolve a Promise that the ServerResponse is closed. As far as I could tell, the res.end callback was not fired. I don't think we need to really wait for it to do so; there is no reason to block the KafkaSSE disconnect() call on this, as it should end eventually asynchronously if we don't.

- The KafkaConsumer was blocking on the sse.end (or res.end) Promise. If this Promise didn't resolve, the KafkaConsumer wouldn't be closed. Instead, use Promise.all to disconnect the KafkaConsumer and the SSE ServerResponse in parallel.

- KafkaSSE disconnect() was being called multiple times for every ClientRequest and ServerResponse end event. Now it should only be called in response to the first one that fires.